### PR TITLE
Make Plugin into a Signaling Server

### DIFF
--- a/lib/dsnp.js
+++ b/lib/dsnp.js
@@ -23,12 +23,20 @@ class DSNP extends EventEmitter{
     this.init();
   }
 
+  /**
+   * initialize signaling services
+   */
   init(){
      console.log('initializing DSNP server over network: %s', this.network);
+     this.clients = []
      this.initHttpServer();
      this.initWebSocketServer();
+     this.httpApp.listen(12034);
   }
 
+  /**
+   * initialize the http server for healthcheck/static content
+   */
   initHttpServer(){
     console.log('creating DSNP HTTP endpoint');
     var file = new NodeStatic.Server('./public');
@@ -39,17 +47,54 @@ class DSNP extends EventEmitter{
     });
   }
 
+  /**
+   * initialize the web socket server for signaling
+   */
   initWebSocketServer(){
     console.log('creating DSNP Web Socket server');
     this.wsApp = new WebSocketServer({
       httpServer: this.httpApp,
       autoAcceptConnections: false
-    }).on('request', this.onRequest);
+    }).on('request', this.onRequest.bind(this));
   }
 
-  onRequest(){
-    this.hasReceivedRequest = true;
+  onRequest(socket){
+    var origin = socket.origin + socket.resource;
+    console.log('received request from: %s', origin)
+    var websocket = socket.accept(null, origin);
+    this.clients.push(websocket);
+    var self = this;
+    websocket.on('message', function(message) {
+      self.handleMessage(websocket, message)});
+    websocket.on('close', function() {
+      self.removeClient(websocket);});
   }
+
+  handleMessage(websocket, message){
+    if (message.type === 'utf8') {
+      console.log('utf8', message.utf8Data);
+      this.clients.forEach(function(previousSocket) {
+        if (previousSocket != websocket) previousSocket.sendUTF(message.utf8Data);
+    });}
+    else if (message.type === 'binary') {
+      console.log('binary', message.binaryData);
+      this.clients.forEach(function(previousSocket) {
+        if (previousSocket != websocket) previousSocket.sendBytes(message.binaryData);
+      });
+    }
+  }
+
+  removeClient(websocket){
+    var newClientsArray = [];
+    for (var i = 0; i < this.clients.length; i++) {
+      var previousSocket = this.clients[i];
+      if (previousSocket != websocket) newClientsArray.push(previousSocket);
+    }
+    this.clients = newClientsArray;
+  }
+
+
+
 }
 
 module.exports = DSNP

--- a/lib/dsnp.js
+++ b/lib/dsnp.js
@@ -72,12 +72,12 @@ class DSNP extends EventEmitter{
 
   handleMessage(websocket, message){
     if (message.type === 'utf8') {
-      console.log('utf8', message.utf8Data);
+      console.log('broadcasting utf8 data', message.utf8Data);
       this.clients.forEach(function(previousSocket) {
         if (previousSocket != websocket) previousSocket.sendUTF(message.utf8Data);
     });}
     else if (message.type === 'binary') {
-      console.log('binary', message.binaryData);
+      console.log('broadcasting binary data', message.binaryData);
       this.clients.forEach(function(previousSocket) {
         if (previousSocket != websocket) previousSocket.sendBytes(message.binaryData);
       });

--- a/lib/dsnp.js
+++ b/lib/dsnp.js
@@ -7,6 +7,9 @@
 'use strict';
 
 const EventEmitter = require('events');
+const NodeStatic = require('node-static');
+const WebSocketServer = require('websocket').server;
+const HTTP = require('http');
 
 class DSNP extends EventEmitter{
   /**
@@ -22,7 +25,30 @@ class DSNP extends EventEmitter{
 
   init(){
      console.log('initializing DSNP server over network: %s', this.network);
+     this.initHttpServer();
+     this.initWebSocketServer();
+  }
 
+  initHttpServer(){
+    console.log('creating DSNP HTTP endpoint');
+    var file = new NodeStatic.Server('./public');
+    this.httpApp = HTTP.createServer(function(request, response) {
+      request.addListener('end', function() {
+        file.serve(request, response);
+      }).resume();
+    });
+  }
+
+  initWebSocketServer(){
+    console.log('creating DSNP Web Socket server');
+    this.wsApp = new WebSocketServer({
+      httpServer: this.httpApp,
+      autoAcceptConnections: false
+    }).on('request', this.onRequest);
+  }
+
+  onRequest(){
+    this.hasReceivedRequest = true;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "bevent": "0.0.2",
     "blgr": "0.0.1",
     "bmutex": "0.0.1",
-    "bufio": "0.0.3"
+    "bufio": "0.0.3",
+    "node-static": "^0.7.10",
+    "websocket": "^1.0.25"
   },
   "devDependencies": {
     "eslint": "^4.17.0",

--- a/test/dsnp-test.js
+++ b/test/dsnp-test.js
@@ -11,4 +11,10 @@ describe('DSNP', function () {
     var dsnp = new DSNP(options)
     assert.equal(dsnp.network, options['network'])
   });
+  it('creates http and ws servers', async () =>{
+    var options = {'network': 'unittest'}
+    var dsnp = new DSNP(options)
+    assert(dsnp.httpApp)
+    assert(dsnp.wsApp)
+  });
 });

--- a/test/dsnp-test.js
+++ b/test/dsnp-test.js
@@ -6,14 +6,14 @@ const DSNP = require('../lib/dsnp');
 const assert = require('assert');
 
 describe('DSNP', function () {
+  var options = {'network': 'unittest'}
+  var dsnp = new DSNP(options)
+
   it('gets the network', async () =>{
-    var options = {'network': 'unittest'}
-    var dsnp = new DSNP(options)
     assert.equal(dsnp.network, options['network'])
   });
+
   it('creates http and ws servers', async () =>{
-    var options = {'network': 'unittest'}
-    var dsnp = new DSNP(options)
     assert(dsnp.httpApp)
     assert(dsnp.wsApp)
   });

--- a/test/dsnp-test.js
+++ b/test/dsnp-test.js
@@ -39,6 +39,12 @@ class FakeAcceptedSocket extends EventEmitter{
     this.origin = fakeSocket.origin
     this.resource = fakeSocket.resource
   }
+  sendUTF(data){
+    this.utfData = data;
+  }
+  sendBytes(data){
+    this.byteData = data;
+  }
 }
 
 describe('DSNP messaging', function () {
@@ -71,10 +77,13 @@ describe('DSNP messaging', function () {
     dsnp.httpApp.close();
   });
 
+  var specialData = 'arethesebytesorutf8?'
   it('handles utf messages', async () =>{
     var dsnp = new DSNP(options);
     dsnp.wsApp.emit('request', socket_alice);
     dsnp.wsApp.emit('request', socket_bob);
+    var alice = dsnp.clients[0];
+    alice.emit('message', {'type': 'utf8', 'utf8Data': specialData});
     dsnp.httpApp.close();
   });
 
@@ -82,6 +91,8 @@ describe('DSNP messaging', function () {
     var dsnp = new DSNP(options);
     dsnp.wsApp.emit('request', socket_alice);
     dsnp.wsApp.emit('request', socket_bob);
+    var alice = dsnp.clients[0];
+    alice.emit('message', {'type': 'binary', 'binaryData': specialData});
     dsnp.httpApp.close();
   });
 });

--- a/test/dsnp-test.js
+++ b/test/dsnp-test.js
@@ -83,7 +83,12 @@ describe('DSNP messaging', function () {
     dsnp.wsApp.emit('request', socket_alice);
     dsnp.wsApp.emit('request', socket_bob);
     var alice = dsnp.clients[0];
+    var bob = dsnp.clients[1];
     alice.emit('message', {'type': 'utf8', 'utf8Data': specialData});
+    assert(!alice.utfData);
+    assert(!alice.byteData);
+    assert.equal(bob.utfData, specialData);
+    assert(!bob.byteData);
     dsnp.httpApp.close();
   });
 
@@ -92,7 +97,12 @@ describe('DSNP messaging', function () {
     dsnp.wsApp.emit('request', socket_alice);
     dsnp.wsApp.emit('request', socket_bob);
     var alice = dsnp.clients[0];
+    var bob = dsnp.clients[1];
     alice.emit('message', {'type': 'binary', 'binaryData': specialData});
+    assert(!alice.utfData);
+    assert(!alice.byteData);
+    assert(!bob.utfData);
+    assert.equal(bob.byteData, specialData);
     dsnp.httpApp.close();
   });
 });

--- a/test/dsnp-test.js
+++ b/test/dsnp-test.js
@@ -53,14 +53,35 @@ describe('DSNP messaging', function () {
     assert.equal(dsnp.clients[1].origin, socket_bob.origin);
     assert.equal(dsnp.clients[0].resource, socket_alice.resource);
     assert.equal(dsnp.clients[1].resource, socket_bob.resource);
+    dsnp.httpApp.close();
   });
 
   it('removes users', async () =>{
+    var dsnp = new DSNP(options);
+    dsnp.wsApp.emit('request', socket_alice);
+    dsnp.wsApp.emit('request', socket_bob);
+    var bob = dsnp.clients[1];
+    bob.emit('close');
+    assert.equal(dsnp.clients.length, 1);
+    assert.equal(dsnp.clients[0].origin, socket_alice.origin);
+    assert.equal(dsnp.clients[0].resource, socket_alice.resource);
+    var alice = dsnp.clients[0];
+    alice.emit('close');
+    assert.equal(dsnp.clients.length, 0);
+    dsnp.httpApp.close();
   });
 
   it('handles utf messages', async () =>{
+    var dsnp = new DSNP(options);
+    dsnp.wsApp.emit('request', socket_alice);
+    dsnp.wsApp.emit('request', socket_bob);
+    dsnp.httpApp.close();
   });
 
   it('handles binary messages', async () =>{
+    var dsnp = new DSNP(options);
+    dsnp.wsApp.emit('request', socket_alice);
+    dsnp.wsApp.emit('request', socket_bob);
+    dsnp.httpApp.close();
   });
 });

--- a/www/index.html
+++ b/www/index.html
@@ -1,0 +1,1 @@
+<title>bDSNP Signaling Server Enabled</title>


### PR DESCRIPTION
⚠️ quick hackathon implementation
these changes make it so that the bDSNP plugin runs a signaling server that handles client registration and simple message broadcasting. added unit testing as well.